### PR TITLE
Fix containers mountpoint in CRI stats provider

### DIFF
--- a/cri/runtime_helpers.go
+++ b/cri/runtime_helpers.go
@@ -81,7 +81,7 @@ func toCriStats(c *lxf.Container) (*rtApi.ContainerStats, error) {
 	disk := rtApi.FilesystemUsage{
 		Timestamp: now,
 		FsId: &rtApi.FilesystemIdentifier{
-			Mountpoint: path.Join(sharedLXD.VarPath("container"), c.ID, "rootfs"),
+			Mountpoint: path.Join(sharedLXD.VarPath("containers"), c.ID, "rootfs"),
 		},
 		UsedBytes:  &rtApi.UInt64Value{Value: st.Stats.FilesystemUsage}, // TODO: root seems not visible? or does it depend?
 		InodesUsed: &rtApi.UInt64Value{Value: 0},                        // TODO: do we have to find out?


### PR DESCRIPTION
The mountpoint path in CRI stats provider seems to be wrong according to the logs from `kubelet`. For instance:

```
E1122 15:44:38.986577   25201 cri_stats_provider.go:376] Failed to get the info of the filesystem with mountpoint "/var/lib/lxd/container/tc4xbxzfxyce7osu/rootfs": failed to get device for dir "/var/lib/lxd/container/tc4xbxzfxyce7osu/rootfs": stat failed on /var/lib/lxd/container/tc4xbxzfxyce7osu/rootfs with error: no such file or directory.
```

To fix it, I had to change the reference to `VarPath` from `container` to `containers`.

I don't know if the TODO are still valid with this change.

Note: It seems that I'm not the only who got this issue, see the following comment: https://github.com/automaticserver/lxe/issues/3#issuecomment-515729408